### PR TITLE
bump simpleclient version to 0.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.apache.tomcat.version>8.5.11</org.apache.tomcat.version>		
-        <io.prometheus.simpleclient.version>0.0.26</io.prometheus.simpleclient.version>
+        <io.prometheus.simpleclient.version>0.1.0</io.prometheus.simpleclient.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
     </properties>


### PR DESCRIPTION
This commit updates the prometheus simpleclient version to the latest (0.1.0) 
Besides the several bugfixes, this also has the benefit of automatically
adding a few more metrics to the exporter.
For example: "Total user and system CPU time spent in seconds."