### PR TITLE
Fixed adding the same metric family more than once when there are many mBeans

### DIFF
--- a/client/src/main/java/nl/nlighten/prometheus/tomcat/TomcatGenericExports.java
+++ b/client/src/main/java/nl/nlighten/prometheus/tomcat/TomcatGenericExports.java
@@ -247,7 +247,7 @@ public class TomcatGenericExports extends Collector {
                         labelList);
 
                 GaugeMetricFamily threadPoolMaxConnectionGauge = new GaugeMetricFamily(
-                            "tomcat_connections_active_max",
+                        "tomcat_connections_active_max",
                         "Maximum number of concurrent connections served by this pool.",
                         labelList);
 
@@ -260,27 +260,28 @@ public class TomcatGenericExports extends Collector {
                         switch (attribute.getName()) {
                             case "currentThreadCount":
                                 threadPoolCurrentCountGauge.addMetric(labelValueList, ((Integer) attribute.getValue()).doubleValue());
-                                mfs.add(threadPoolCurrentCountGauge);
                                 break;
                             case "currentThreadsBusy":
                                 threadPoolActiveCountGauge.addMetric(labelValueList, ((Integer) attribute.getValue()).doubleValue());
-                                mfs.add(threadPoolActiveCountGauge);
                                 break;
                             case "maxThreads":
                                 threadPoolMaxThreadsGauge.addMetric(labelValueList, ((Integer) attribute.getValue()).doubleValue());
-                                mfs.add(threadPoolMaxThreadsGauge);
                                 break;
                             case "connectionCount":
                                 threadPoolConnectionCountGauge.addMetric(labelValueList, ((Long) attribute.getValue()).doubleValue());
-                                mfs.add(threadPoolConnectionCountGauge);
                                 break;
                             case "maxConnections":
                                 threadPoolMaxConnectionGauge.addMetric(labelValueList, ((Integer) attribute.getValue()).doubleValue());
-                                mfs.add(threadPoolMaxConnectionGauge);
 
                         }
                     }
                 }
+
+                addNonEmptyMetricFamily(mfs, threadPoolCurrentCountGauge);
+                addNonEmptyMetricFamily(mfs, threadPoolActiveCountGauge);
+                addNonEmptyMetricFamily(mfs, threadPoolMaxThreadsGauge);
+                addNonEmptyMetricFamily(mfs, threadPoolConnectionCountGauge);
+                addNonEmptyMetricFamily(mfs, threadPoolMaxConnectionGauge);
             }
         } catch (Exception e) {
             log.error("Error retrieving metric:" + e.getMessage());
@@ -295,6 +296,13 @@ public class TomcatGenericExports extends Collector {
                 Arrays.asList("version", "build"));
         tomcatInfo.addMetric(Arrays.asList(ServerInfo.getServerNumber(), ServerInfo.getServerBuilt()), 1);
         mfs.add(tomcatInfo);
+    }
+
+
+    private void addNonEmptyMetricFamily(List<MetricFamilySamples> mfs, GaugeMetricFamily metricFamily) {
+        if (metricFamily.samples.size() > 0) {
+            mfs.add(metricFamily);
+        }
     }
 
 


### PR DESCRIPTION
In current version, when there is more than one connector (e.g. AJP and HTTP connector), metrics for each connector is added as many times as number of connectors. This lead to the `/metrics` endpoint being unparsable for the Prometheus.

Consider the below example of this issue:
```
# HELP tomcat_threads_total Number threads in this pool.
# TYPE tomcat_threads_total gauge
tomcat_threads_total{name="ajp-nio-8109",} 10.0
tomcat_threads_total{name="http-nio-8180",} 18.0
# HELP tomcat_threads_active_total Number of active threads in this pool.
# TYPE tomcat_threads_active_total gauge
tomcat_threads_active_total{name="ajp-nio-8109",} 0.0
tomcat_threads_active_total{name="http-nio-8180",} 7.0
# HELP tomcat_threads_max Maximum number of threads allowed in this pool.
# TYPE tomcat_threads_max gauge
tomcat_threads_max{name="ajp-nio-8109",} 200.0
tomcat_threads_max{name="http-nio-8180",} 200.0
# HELP tomcat_connections_active_total Number of connections served by this pool.
# TYPE tomcat_connections_active_total gauge
tomcat_connections_active_total{name="ajp-nio-8109",} 1.0
tomcat_connections_active_total{name="http-nio-8180",} 8.0
# HELP tomcat_connections_active_max Maximum number of concurrent connections served by this pool.
# TYPE tomcat_connections_active_max gauge
tomcat_connections_active_max{name="ajp-nio-8109",} 10000.0
tomcat_connections_active_max{name="http-nio-8180",} 10000.0
# HELP tomcat_threads_total Number threads in this pool.
# TYPE tomcat_threads_total gauge
tomcat_threads_total{name="ajp-nio-8109",} 10.0
tomcat_threads_total{name="http-nio-8180",} 18.0
# HELP tomcat_threads_active_total Number of active threads in this pool.
# TYPE tomcat_threads_active_total gauge
tomcat_threads_active_total{name="ajp-nio-8109",} 0.0
tomcat_threads_active_total{name="http-nio-8180",} 7.0
# HELP tomcat_threads_max Maximum number of threads allowed in this pool.
# TYPE tomcat_threads_max gauge
tomcat_threads_max{name="ajp-nio-8109",} 200.0
tomcat_threads_max{name="http-nio-8180",} 200.0
# HELP tomcat_connections_active_total Number of connections served by this pool.
# TYPE tomcat_connections_active_total gauge
tomcat_connections_active_total{name="ajp-nio-8109",} 1.0
tomcat_connections_active_total{name="http-nio-8180",} 8.0
# HELP tomcat_connections_active_max Maximum number of concurrent connections served by this pool.
# TYPE tomcat_connections_active_max gauge
tomcat_connections_active_max{name="ajp-nio-8109",} 10000.0
tomcat_connections_active_max{name="http-nio-8180",} 10000.0
# HELP tomcat_requestprocessor_received_bytes Number of bytes received by this request processor
# TYPE tomcat_requestprocessor_received_bytes gauge
tomcat_requestprocessor_received_bytes{name="http-nio-8180",} 0.0
tomcat_requestprocessor_received_bytes{name="ajp-nio-8109",} 0.0
# HELP tomcat_requestprocessor_sent_bytes Number of bytes sent by this request processor
# TYPE tomcat_requestprocessor_sent_bytes gauge
tomcat_requestprocessor_sent_bytes{name="http-nio-8180",} 0.0
tomcat_requestprocessor_sent_bytes{name="ajp-nio-8109",} 0.0
# HELP tomcat_requestprocessor_time_seconds The total time spend by this request processor
# TYPE tomcat_requestprocessor_time_seconds gauge
tomcat_requestprocessor_time_seconds{name="http-nio-8180",} 1.249
tomcat_requestprocessor_time_seconds{name="ajp-nio-8109",} 0.0
# HELP tomcat_requestprocessor_request_count The number of request served by this request processor
# TYPE tomcat_requestprocessor_request_count counter
tomcat_requestprocessor_request_count{name="http-nio-8180",} 11.0
tomcat_requestprocessor_request_count{name="ajp-nio-8109",} 0.0
# HELP tomcat_requestprocessor_error_count The number of error request served by this request processor
# TYPE tomcat_requestprocessor_error_count counter
tomcat_requestprocessor_error_count{name="http-nio-8180",} 0.0
tomcat_requestprocessor_error_count{name="ajp-nio-8109",} 0.0
```

As you can see, five metric families are added twice, each of them having two metric instances inside.
These metric families are: `tomcat_threads_total`, `tomcat_threads_active_total`, `tomcat_threads_max`, `tomcat_connections_active_total` and `tomcat_connections_active_max`.