### PR TITLE
To reduce the chance of flaky test failure

### DIFF
--- a/client/src/test/java/nl/nlighten/prometheus/tomcat/TomcatServletMetricsFilterTest.java
+++ b/client/src/test/java/nl/nlighten/prometheus/tomcat/TomcatServletMetricsFilterTest.java
@@ -27,6 +27,7 @@ public class TomcatServletMetricsFilterTest extends AbstractTomcatMetricsTest {
     public void testServletRequestMetrics() throws Exception {
         // servlet response times
         assertThat(CollectorRegistry.defaultRegistry.getSampleValue("servlet_request_seconds_bucket", new String[]{"context", "method", "le"}, new String[]{CONTEXT_PATH, "GET", "0.01"}), is(notNullValue()));
+        try {Thread.sleep(10);} catch (InterruptedException ie) {}
         assertThat(CollectorRegistry.defaultRegistry.getSampleValue("servlet_request_seconds_bucket", new String[]{"context", "method", "le"}, new String[]{CONTEXT_PATH, "GET", "+Inf"}), is(greaterThan(0.0)));
         assertThat(CollectorRegistry.defaultRegistry.getSampleValue("servlet_request_seconds_count", new String[]{"context", "method"}, new String[]{CONTEXT_PATH, "GET"}), is(greaterThan(0.0)));
 


### PR DESCRIPTION
**Description:**
This test is flakily fails. I run this test many times and it makes assertion fails. The failure message is as follows.

**Failure:**

[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.51 s <<< FAILURE! - in nl.nlighten.prometheus.tomcat.TomcatServletMetricsFilterTest
[ERROR] testServletRequestMetrics(nl.nlighten.prometheus.tomcat.TomcatServletMetricsFilterTest)  Time elapsed: 0.01 s  <<< FAILURE!  
java.lang.AssertionError: 
Expected: is a value greater than <0.0>
     but: <0.0> was equal to <0.0>
	at nl.nlighten.prometheus.tomcat.TomcatServletMetricsFilterTest.testServletRequestMetrics(TomcatServletMetricsFilterTest.java:31)

[ERROR] Failures: 
[ERROR]   TomcatServletMetricsFilterTest.testServletRequestMetrics:31 
Expected: is a value greater than <0.0>
     but: <0.0> was equal to <0.0>
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
