### PR TITLE
Fix Test Flakiness

### DIFF
--- a/client/src/main/java/nl/nlighten/prometheus/tomcat/TomcatServletMetricsFilter.java
+++ b/client/src/main/java/nl/nlighten/prometheus/tomcat/TomcatServletMetricsFilter.java
@@ -49,6 +49,7 @@ import java.io.IOException;
  *  </pre>
  */
 public class TomcatServletMetricsFilter implements Filter {
+    private static volatile boolean hasExecuted;
     private static final String BUCKET_CONFIG_PARAM = "buckets";
     private static Histogram servletLatency;
     private static Gauge servletConcurrentRequest;
@@ -116,12 +117,17 @@ public class TomcatServletMetricsFilter implements Filter {
                 filterChain.doFilter(servletRequest, servletResponse);
             } finally {
                 timer.observeDuration();
+                hasExecuted=true;
                 servletConcurrentRequest.labels(context).dec();
                 servletStatusCodes.labels(context, Integer.toString(getStatus((HttpServletResponse) servletResponse))).inc();
             }
         } else {
             filterChain.doFilter(servletRequest, servletResponse);
         }
+    }
+    
+    public static boolean getExecutedStatus() {
+        return hasExecuted;
     }
 
     private int getStatus(HttpServletResponse response) {

--- a/client/src/test/java/nl/nlighten/prometheus/tomcat/TomcatServletMetricsFilterTest.java
+++ b/client/src/test/java/nl/nlighten/prometheus/tomcat/TomcatServletMetricsFilterTest.java
@@ -27,6 +27,9 @@ public class TomcatServletMetricsFilterTest extends AbstractTomcatMetricsTest {
     public void testServletRequestMetrics() throws Exception {
         // servlet response times
         assertThat(CollectorRegistry.defaultRegistry.getSampleValue("servlet_request_seconds_bucket", new String[]{"context", "method", "le"}, new String[]{CONTEXT_PATH, "GET", "0.01"}), is(notNullValue()));
+        while (! TomcatServletMetricsFilter.getExecutedStatus()) { 
+            Thread.yield(); 
+        }
         assertThat(CollectorRegistry.defaultRegistry.getSampleValue("servlet_request_seconds_bucket", new String[]{"context", "method", "le"}, new String[]{CONTEXT_PATH, "GET", "+Inf"}), is(greaterThan(0.0)));
         assertThat(CollectorRegistry.defaultRegistry.getSampleValue("servlet_request_seconds_count", new String[]{"context", "method"}, new String[]{CONTEXT_PATH, "GET"}), is(greaterThan(0.0)));
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
I observed a previous fix injected some delay to fix the flaky test, but I believe that fix might be unstable in a CI environment or when run on different machines, given the dependency on some constant wait time. I suggest a new way to fix the test by adding some synchronization for the test execution only. I at first identify the source code location whose slow execution leads to the flaky test failure, where if client/src/main/java/nl/nlighten/prometheus/tomcat/TomcatServletMetricsFilter.java#119 slows the timer.observeDuration, then the test fails (client/src/test/java/nl/nlighten/prometheus/tomcat/TomcatServletMetricsFilterTest.java#30). Hence, I introduce one variable in this class [TomcatServletMetricsFilter.java] that is only there to provide some synchronization. Basically, until this statement executed, I force the thread that the test runs on to wait before it executes the assertions at Line 30. The waiting location is at client/src/test/java/nl/nlighten/prometheus/tomcat/TomcatServletMetricsFilterTest.java#30

### Why are the changes needed?
This test is flakily fails. I run this test many times and it makes assertion fails. The failure message is as follows.

**Failure:**

[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.51 s <<< FAILURE! - in nl.nlighten.prometheus.tomcat.TomcatServletMetricsFilterTest
[ERROR] testServletRequestMetrics(nl.nlighten.prometheus.tomcat.TomcatServletMetricsFilterTest) Time elapsed: 0.01 s <<< FAILURE!
java.lang.AssertionError:
Expected: is a value greater than <0.0>
but: <0.0> was equal to <0.0>
at nl.nlighten.prometheus.tomcat.TomcatServletMetricsFilterTest.testServletRequestMetrics(TomcatServletMetricsFilterTest.java:31)

[ERROR] Failures:
[ERROR] TomcatServletMetricsFilterTest.testServletRequestMetrics:31
Expected: is a value greater than <0.0>
but: <0.0> was equal to <0.0>
[INFO]
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

### Result:

With my changes, I run the test 1000 times and every time it passes the test.